### PR TITLE
Dockerfile: clean up

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -6,14 +6,11 @@ RUN apt-get update
 RUN apt-get install -y openssl ca-certificates
 RUN apt-get install -y libffi-dev build-essential libssl-dev git rustc cargo
 RUN pip install pip -U
-COPY requirements_dev.txt .
-COPY requirements.txt .
-RUN pip install -r requirements_dev.txt -U
+COPY . $workdir
 RUN pip install -r requirements.txt -U
+RUN pip install .
 RUN apt-get remove --purge -y libffi-dev build-essential libssl-dev git rustc cargo
 RUN rm -rf /root/.cargo
-COPY . $workdir
-RUN pip install .
 
 # Squash layers
 FROM python:3.9-slim


### PR DESCRIPTION
This commit fixes the way that we install the local package. Previsouly,
pip install . was executed after all of the build-tooling was
uninstalled. This did not fail because we conveniently have no
Git dependencies int our setup.cfg. If we did happen to be tracking
some Git dependencies, this step would fail because Git was no longer
installed. This commit fixes the bug by reordering the pip install .
step before the removal of these build tools.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

This PR is the same as https://github.com/mietright/meowlflow/pull/34 and https://github.com/mietright/eee/pull/4/commits/e31b389be223a22aa26ca76f489b635039033a80 from eee